### PR TITLE
Fix maxFileSize check

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -235,7 +235,7 @@
             if (typeof file === 'undefined') {
                 return 'Missing file';
             }
-            if (fileConfig.maxFileSize && file.size > fileConfig.maxFileSize) {
+            if (fileConfig.maxFileSize && file.file.size > fileConfig.maxFileSize) {
                 return 'File size too large. Maximum size allowed is ' + fileConfig.maxFileSize;
             }
             if (typeof file.name === 'undefined') {


### PR DESCRIPTION
The file object here has another file object with size property.
So we need to call `file.file.size` to actually get the size here otherwise it will return null
